### PR TITLE
Remove repo.yml instead of creating one

### DIFF
--- a/flowzonify.sh
+++ b/flowzonify.sh
@@ -2,8 +2,8 @@
 
 git checkout -b "flowzonify";
 
-if [[ ! -f "repo.yml" ]]; then
-	printf "type: 'node'\n" > repo.yml
+if [[ -f "repo.yml" ]]; then
+	rm repo.yml
 	git add repo.yml
 fi
 


### PR DESCRIPTION
Flowzone no longer looks for a repo.yml file to enable versioning and such it's no longer required and can be removed

Change-type: patch